### PR TITLE
refactor: move image helpers to lib

### DIFF
--- a/back-end/lib/image.js
+++ b/back-end/lib/image.js
@@ -1,0 +1,22 @@
+// lib/image.js
+
+/**
+ * Build a Cloudinary CDN URL for an image.
+ */
+export function cdnUrl(publicId) {
+  const cloud = process.env.NEXT_PUBLIC_CLOUDINARY_CLOUD_NAME || process.env.CLOUDINARY_CLOUD_NAME;
+  return `https://res.cloudinary.com/${cloud}/image/upload/f_auto,q_auto/${publicId}`;
+}
+
+/**
+ * Map a simple aspect ratio string to a DALL·E 3 size.
+ * Defaults to "1024x1024" if the ratio is unrecognized.
+ */
+export function sizeForAR(ar) {
+  const s = (ar || "").trim();
+  if (s === "16:9") return "1792x1024";
+  if (s === "9:16") return "1024x1792";
+  return "1024x1024"; // 1:1 default
+}
+
+export default { cdnUrl, sizeForAR };

--- a/back-end/routes/art.js
+++ b/back-end/routes/art.js
@@ -4,6 +4,7 @@ import express from "express";
 import { createClient } from "@supabase/supabase-js";
 import openai from "../lib/openai.js";
 import cloudinary from "../lib/cloudinary.js";
+import { cdnUrl, sizeForAR } from "../lib/image.js";
 
 const router = express.Router();
 
@@ -17,17 +18,6 @@ function sbForUser(accessToken) {
   });
 }
 
-function cdnUrl(publicId) {
-  const cloud = process.env.NEXT_PUBLIC_CLOUDINARY_CLOUD_NAME || process.env.CLOUDINARY_CLOUD_NAME;
-  return `https://res.cloudinary.com/${cloud}/image/upload/f_auto,q_auto/${publicId}`;
-}
-
-function sizeForAR(ar) {
-  const s = (ar || "").trim();
-  if (s === "16:9") return "1792x1024";
-  if (s === "9:16") return "1024x1792";
-  return "1024x1024"; // 1:1 default
-}
 
 // 1) DALL·E 3: always return a Buffer
 export async function dalleBuffer({ prompt, size = "1024x1024", negative = "" }) {


### PR DESCRIPTION
## Summary
- centralize `cdnUrl` and `sizeForAR` in new `lib/image.js`
- import shared image helpers in `routes/art.js`

## Testing
- `cd back-end && npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68ae11e8379c8320be2cbeaa02ed96ec