### PR TITLE
refactor: move image generation helpers to service

### DIFF
--- a/back-end/routes/art.js
+++ b/back-end/routes/art.js
@@ -4,6 +4,7 @@ import express from "express";
 import { createClient } from "@supabase/supabase-js";
 import openai from "../lib/openai.js";
 import cloudinary from "../lib/cloudinary.js";
+import { dalleBuffer, uploadToCloudinaryBuffer } from "../services/imageGeneration.js";
 
 const router = express.Router();
 
@@ -28,48 +29,6 @@ function sizeForAR(ar) {
   if (s === "9:16") return "1024x1792";
   return "1024x1024"; // 1:1 default
 }
-
-// 1) DALL·E 3: always return a Buffer
-export async function dalleBuffer({ prompt, size = "1024x1024", negative = "" }) {
-  const fullPrompt = negative ? `${prompt}\n\nAvoid: ${negative}` : prompt;
-  const resp = await openai.images.generate({
-    model: "dall-e-3",
-    prompt: fullPrompt,
-    size, // "1024x1024" | "1792x1024" | "1024x1792"
-    response_format: "b64_json",
-  });
-  const b64 = resp?.data?.[0]?.b64_json || "";
-  const buf = Buffer.from(b64, "base64");
-  if (!Buffer.isBuffer(buf)) throw new Error("dalleBuffer: result is not a Buffer");
-  return buf;
-}
-
-// 2) Cloudinary upload: require a Buffer
-// services/artGeneration.js (or wherever your helper lives)
-export async function uploadToCloudinaryBuffer({ buffer, publicId, folder = "brandos" }) {
-  if (!Buffer.isBuffer(buffer)) {
-    throw new Error(`uploadToCloudinaryBuffer: expected Buffer, got ${Object.prototype.toString.call(buffer)}`);
-  }
-
-  const dataUri = `data:image/png;base64,${buffer.toString("base64")}`;
-
-  // simple retry with backoff
-  for (let attempt = 1; attempt <= 3; attempt++) {
-    try {
-      const res = await cloudinary.uploader.upload(dataUri, {
-        public_id: publicId,
-        folder,
-        resource_type: "image",
-        timeout: 60000, // 60s
-      });
-      return res;
-    } catch (e) {
-      if (attempt === 3) throw e;
-      await new Promise(r => setTimeout(r, 750 * attempt));
-    }
-  }
-}
-
 /* ------------------------------------------------------------------ */
 /* GPT prompt crafting for folder (Brand + DCA → image prompts)       */
 /* ------------------------------------------------------------------ */

--- a/back-end/services/imageGeneration.js
+++ b/back-end/services/imageGeneration.js
@@ -1,0 +1,45 @@
+// services/imageGeneration.js
+
+import openai from "../lib/openai.js";
+import cloudinary from "../lib/cloudinary.js";
+
+// 1) DALL·E 3: always return a Buffer
+export async function dalleBuffer({ prompt, size = "1024x1024", negative = "" }) {
+  const fullPrompt = negative ? `${prompt}\n\nAvoid: ${negative}` : prompt;
+  const resp = await openai.images.generate({
+    model: "dall-e-3",
+    prompt: fullPrompt,
+    size, // "1024x1024" | "1792x1024" | "1024x1792"
+    response_format: "b64_json",
+  });
+  const b64 = resp?.data?.[0]?.b64_json || "";
+  const buf = Buffer.from(b64, "base64");
+  if (!Buffer.isBuffer(buf)) throw new Error("dalleBuffer: result is not a Buffer");
+  return buf;
+}
+
+// 2) Cloudinary upload: require a Buffer
+export async function uploadToCloudinaryBuffer({ buffer, publicId, folder = "brandos" }) {
+  if (!Buffer.isBuffer(buffer)) {
+    throw new Error(`uploadToCloudinaryBuffer: expected Buffer, got ${Object.prototype.toString.call(buffer)}`);
+  }
+
+  const dataUri = `data:image/png;base64,${buffer.toString("base64")}`;
+
+  // simple retry with backoff
+  for (let attempt = 1; attempt <= 3; attempt++) {
+    try {
+      const res = await cloudinary.uploader.upload(dataUri, {
+        public_id: publicId,
+        folder,
+        resource_type: "image",
+        timeout: 60000, // 60s
+      });
+      return res;
+    } catch (e) {
+      if (attempt === 3) throw e;
+      await new Promise(r => setTimeout(r, 750 * attempt));
+    }
+  }
+}
+


### PR DESCRIPTION
## Summary
- move dalleBuffer and uploadToCloudinaryBuffer helpers into new `services/imageGeneration.js`
- update `routes/art.js` to import the shared helpers

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ae11cd4b048320a24c646060ad2077