### PR TITLE
chore: import zod in brand schema

### DIFF
--- a/back-end/schemas/brand.js
+++ b/back-end/schemas/brand.js
@@ -1,4 +1,5 @@
 // schemas/brand.js
+import { z } from "zod";
 
 export const PlatformItem = z.object({
   name: z.string().min(1),


### PR DESCRIPTION
## Summary
- add missing zod import to brand schema

## Testing
- `npm test` (fails: Error: no test specified)


------
https://chatgpt.com/codex/tasks/task_e_68ae16a7d5308320b404e0e262aa283b