### PR TITLE
Refactor brand finalize prompt to shared constant

### DIFF
--- a/back-end/routes/brand.js
+++ b/back-end/routes/brand.js
@@ -6,6 +6,7 @@ import { createClient } from "@supabase/supabase-js";
 import { v4 as uuidv4 } from 'uuid';
 import { generateForFolder } from "../services/art.js";
 import openai from "../lib/openai.js";
+import { BRAND_FINALIZE_PROMPT } from "../prompts/brand.js";
 
 const router = express.Router();
 
@@ -98,47 +99,7 @@ async function buildContextForSession(sb, session_id) {
 
   const system = {
     role: "system",
-    content:
-`You are BrandBot. Output ONLY valid JSON (no markdown) that matches:
-
-type Final = {
-  brand: {
-    name: string;
-    description: string;
-    product_type: string;
-    features?: string[];
-    benefits?: string[];
-    differentiation: string;
-    tone_of_voice?: string;
-    mission?: string;
-    vision?: string;
-    values?: string[];
-    competitors?: string[];
-    target_audience?: string;
-    target_platforms?: { name: string; goal?: string }[];
-    stage?: "idea" | "prototype" | "launched" | "growth";
-    system_prompt?: string;
-    onboarding_summary?: string;
-    metadata?: Record<string, any>;
-  };
-  dca: {
-    name: string;
-    demographics?: Record<string, any>;
-    career?: Record<string, any>;
-    psychographics?: Record<string, any>;
-    digital_behavior?: Record<string, any>;
-    buying_behavior?: Record<string, any>;
-    pain_points?: string[];
-    backstory?: string;
-    system_prompt?: string;
-    metadata?: Record<string, any>;
-  };
-}
-
-Rules:
-- JSON ONLY. No commentary.
-- Fill optional fields sensibly from context; concise but specific.
-- If unknown, use empty arrays/objects/strings (not null).`
+    content: BRAND_FINALIZE_PROMPT,
   };
 
   const userBlob = [


### PR DESCRIPTION
## Summary
- reuse shared `BRAND_FINALIZE_PROMPT` in brand routes
- remove duplicate inline system prompt string

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68ae16bca0488320bbf1dea49622286b