### PR TITLE
Refactor art prompt generation

### DIFF
--- a/back-end/prompts/art.js
+++ b/back-end/prompts/art.js
@@ -1,0 +1,27 @@
+// prompts/art.js
+
+export const IMAGE_PROMPTS_SYSTEM = `Return JSON ONLY:
+{"brand_thumbnail":{"prompt":string,"negative":string,"aspect_ratio":"16:9"|"1:1"|"9:16"},
+ "dca_avatar":{"prompt":string,"negative":string,"aspect_ratio":"1:1"}}
+Concise (1–3 sentences). No logos/text.`;
+
+export function buildImagePromptsUser(brand, dca) {
+  return `BRAND:\n${JSON.stringify({
+    name: brand.name,
+    product_type: brand.product_type,
+    description: brand.description,
+    differentiation: brand.differentiation,
+    tone_of_voice: brand.tone_of_voice || "",
+    values: brand.values || [],
+    stage: brand.stage || "idea",
+  }, null, 2)}
+DCA:\n${JSON.stringify({
+    name: dca.name,
+    demographics: dca.demographics || {},
+    psychographics: dca.psychographics || {},
+    digital_behavior: dca.digital_behavior || {},
+    buying_behavior: dca.buying_behavior || {},
+    pain_points: dca.pain_points || [],
+    backstory: dca.backstory || "",
+  }, null, 2)}`;
+}

--- a/back-end/services/artPrompts.js
+++ b/back-end/services/artPrompts.js
@@ -1,36 +1,11 @@
 // services/artPrompts.js
 import openai from "../lib/openai.js";
-
-function sizeForAR(ar) {
-  const s = (ar || "").trim();
-  if (s === "16:9") return "1792x1024";
-  if (s === "9:16") return "1024x1792";
-  return "1024x1024"; // 1:1 default
-}
+import { sizeForAR } from "../lib/image.js";
+import { IMAGE_PROMPTS_SYSTEM, buildImagePromptsUser } from "../prompts/art.js";
 
 export async function getImagePromptsForFolder(brand, dca) {
-  const system = `Return JSON ONLY:
-{"brand_thumbnail":{"prompt":string,"negative":string,"aspect_ratio":"16:9"|"1:1"|"9:16"},
- "dca_avatar":{"prompt":string,"negative":string,"aspect_ratio":"1:1"}}
-Concise (1–3 sentences). No logos/text.`;
-  const user = `BRAND:\n${JSON.stringify({
-    name: brand.name,
-    product_type: brand.product_type,
-    description: brand.description,
-    differentiation: brand.differentiation,
-    tone_of_voice: brand.tone_of_voice || "",
-    values: brand.values || [],
-    stage: brand.stage || "idea",
-  }, null, 2)}
-DCA:\n${JSON.stringify({
-    name: dca.name,
-    demographics: dca.demographics || {},
-    psychographics: dca.psychographics || {},
-    digital_behavior: dca.digital_behavior || {},
-    buying_behavior: dca.buying_behavior || {},
-    pain_points: dca.pain_points || [],
-    backstory: dca.backstory || "",
-  }, null, 2)}`;
+  const system = IMAGE_PROMPTS_SYSTEM;
+  const user = buildImagePromptsUser(brand, dca);
 
   const resp = await openai.chat.completions.create({
     model: "gpt-4o", // or "gpt-4o-mini",


### PR DESCRIPTION
## Summary
- reuse shared `sizeForAR` helper instead of local implementation
- extract system and user image prompt templates into `prompts/art.js`
- update `getImagePromptsForFolder` to use centralized prompt helpers

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68ae16c3a85c8320ae3a43e74c6ea377