### PR TITLE
refactor: import art helpers from services

### DIFF
--- a/back-end/routes/art.js
+++ b/back-end/routes/art.js
@@ -1,77 +1,16 @@
 // routes/art.js
 
 import express from "express";
-import openai from "../lib/openai.js";
-import cloudinary from "../lib/cloudinary.js";
 import { dalleBuffer, uploadToCloudinaryBuffer } from "../services/imageGeneration.js";
 import { getImagePromptsForFolder } from "../services/artPrompts.js";
 
 import { supabaseForUser } from "../lib/supabase.js";
 
-import { cdnUrl, sizeForAR } from "../lib/image.js";
+import { cdnUrl } from "../lib/image.js";
 
 
 
 const router = express.Router();
-
-/* ------------------------------------------------------------------ */
-/* Setup helpers                                                      */
-/* ------------------------------------------------------------------ */
-
-
-function cdnUrl(publicId) {
-  const cloud = process.env.NEXT_PUBLIC_CLOUDINARY_CLOUD_NAME || process.env.CLOUDINARY_CLOUD_NAME;
-  return `https://res.cloudinary.com/${cloud}/image/upload/f_auto,q_auto/${publicId}`;
-}
-
-function sizeForAR(ar) {
-  const s = (ar || "").trim();
-  if (s === "16:9") return "1792x1024";
-  if (s === "9:16") return "1024x1792";
-  return "1024x1024"; // 1:1 default
-}
-
-// 1) DALL·E 3: always return a Buffer
-export async function dalleBuffer({ prompt, size = "1024x1024", negative = "" }) {
-  const fullPrompt = negative ? `${prompt}\n\nAvoid: ${negative}` : prompt;
-  const resp = await openai.images.generate({
-    model: "dall-e-3",
-    prompt: fullPrompt,
-    size, // "1024x1024" | "1792x1024" | "1024x1792"
-    response_format: "b64_json",
-  });
-  const b64 = resp?.data?.[0]?.b64_json || "";
-  const buf = Buffer.from(b64, "base64");
-  if (!Buffer.isBuffer(buf)) throw new Error("dalleBuffer: result is not a Buffer");
-  return buf;
-}
-
-// 2) Cloudinary upload: require a Buffer
-// services/artGeneration.js (or wherever your helper lives)
-export async function uploadToCloudinaryBuffer({ buffer, publicId, folder = "brandos" }) {
-  if (!Buffer.isBuffer(buffer)) {
-    throw new Error(`uploadToCloudinaryBuffer: expected Buffer, got ${Object.prototype.toString.call(buffer)}`);
-  }
-
-  const dataUri = `data:image/png;base64,${buffer.toString("base64")}`;
-
-  // simple retry with backoff
-  for (let attempt = 1; attempt <= 3; attempt++) {
-    try {
-      const res = await cloudinary.uploader.upload(dataUri, {
-        public_id: publicId,
-        folder,
-        resource_type: "image",
-        timeout: 60000, // 60s
-      });
-      return res;
-    } catch (e) {
-      if (attempt === 3) throw e;
-      await new Promise(r => setTimeout(r, 750 * attempt));
-    }
-  }
-}
-
 
 /* ------------------------------------------------------------------ */
 /* A) Generic: generate from a prompt                                  */
@@ -183,8 +122,4 @@ router.post("/generate-from-prompt", async (req, res) => {
     return res.status(500).json({ error: "Image generation failed" });
   }
 });
-
-
-
-export { getImagePromptsForFolder };
 export default router;

--- a/back-end/services/art.js
+++ b/back-end/services/art.js
@@ -1,6 +1,7 @@
 // services/art.js
 
-import { getImagePromptsForFolder, dalleBuffer, uploadToCloudinaryBuffer } from "../routes/art.js";
+import { getImagePromptsForFolder } from "../services/artPrompts.js";
+import { dalleBuffer, uploadToCloudinaryBuffer } from "../services/imageGeneration.js";
 import cloudinary from "../lib/cloudinary.js";
 
 export async function generateForFolder({ sb, user_id, folder_id }) {


### PR DESCRIPTION
## Summary
- replace art service's dependency on routes with direct imports from service modules
- clean up art routes to use shared helpers from services

## Testing
- `npm test` (fails: no test specified)


------
https://chatgpt.com/codex/tasks/task_e_68ae16db9418832088af995e97c19d09