### PR TITLE
refactor: centralize brand schemas

### DIFF
--- a/back-end/routes/brand.js
+++ b/back-end/routes/brand.js
@@ -1,11 +1,11 @@
 // routes/brand.js
 
 import express from "express";
-import { custom, z } from "zod";
 import { createClient } from "@supabase/supabase-js";
 import { v4 as uuidv4 } from 'uuid';
 import { generateForFolder } from "../services/art.js";
 import openai from "../lib/openai.js";
+import { PlatformItem, BrandZ, DcaZ, FinalZ } from "../schemas/brand.js";
 
 const router = express.Router();
 
@@ -25,48 +25,7 @@ function supabaseForUser(accessToken) {
   );
 }
 
-/* ==========
-   Zod Schemas
-   ========== */
-const PlatformItem = z.object({
-  name: z.string().min(1),
-  goal: z.string().optional(),
-});
 
-const BrandZ = z.object({
-  name: z.string().min(1),
-  description: z.string().min(1),
-  product_type: z.string().min(1),
-  features: z.array(z.string()).optional().default([]),
-  benefits: z.array(z.string()).optional().default([]),
-  differentiation: z.string().min(1),
-  tone_of_voice: z.string().optional(),
-  mission: z.string().optional(),
-  vision: z.string().optional(),
-  values: z.array(z.string()).optional().default([]),
-  competitors: z.array(z.string()).optional().default([]),
-  target_audience: z.string().optional().default(""),
-  target_platforms: z.array(PlatformItem).optional().default([]),
-  stage: z.enum(["idea", "prototype", "launched", "growth"]).optional().default("idea"),
-  system_prompt: z.string().optional().default(""),
-  onboarding_summary: z.string().optional().default(""),
-  metadata: z.record(z.any()).optional().default({}),
-});
-
-const DcaZ = z.object({
-  name: z.string().min(1),
-  demographics: z.record(z.any()).optional().default({}),
-  career: z.record(z.any()).optional().default({}),
-  psychographics: z.record(z.any()).optional().default({}),
-  digital_behavior: z.record(z.any()).optional().default({}),
-  buying_behavior: z.record(z.any()).optional().default({}),
-  pain_points: z.array(z.string()).optional().default([]),
-  backstory: z.string().optional().default(""),
-  system_prompt: z.string().optional().default(""),
-  metadata: z.record(z.any()).optional().default({}),
-});
-
-const FinalZ = z.object({ brand: BrandZ, dca: DcaZ });
 
 /* =========================
    Context & OpenAI helpers

--- a/back-end/schemas/brand.js
+++ b/back-end/schemas/brand.js
@@ -1,5 +1,7 @@
 // schemas/brand.js
 
+import { z } from "zod";
+
 export const PlatformItem = z.object({
   name: z.string().min(1),
   goal: z.string().optional(),


### PR DESCRIPTION
## Summary
- reuse shared brand schemas in brand route
- add missing zod import to brand schemas module

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68ae16b1de3c8320b02c3221f5c18453