### PR TITLE
refactor: use textApi helper for summarization

### DIFF
--- a/back-end/routes/chat.js
+++ b/back-end/routes/chat.js
@@ -2,11 +2,6 @@
 
 import express from "express";
 import actionCall from "../lib/textApi.js";
-import dotenv from "dotenv";
-import { OpenAI } from "openai";
-const openai = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
-
-dotenv.config();
 
 const router = express.Router();
 router.use(express.json());
@@ -46,15 +41,16 @@ router.post("/summarize", async (req, res) => {
       return res.status(400).json({ message: "Invalid messages format. Each message must have a role and string content." });
     }
 
-    const response = await openai.chat.completions.create({
-      model: "gpt-4o", // Cheaper & faster model for summarization
-      messages: [
-        { role: "system", content: "Summarize this conversation concisely for memory purposes. Be objective and capture the key ideas. Make it as short as you can without loss of clarity." },
-        ...messages
-      ],
-    });
+    const summaryMessages = [
+      {
+        role: "system",
+        content:
+          "Summarize this conversation concisely for memory purposes. Be objective and capture the key ideas. Make it as short as you can without loss of clarity.",
+      },
+      ...messages,
+    ];
 
-    const summary = response.choices[0]?.message?.content?.trim() || "No summary.";
+    const summary = await actionCall(summaryMessages, { model: "gpt-4o" });
 
     res.status(200).json({ summary });
   } catch (error) {


### PR DESCRIPTION
## Summary
- refactor /summarize endpoint to call shared actionCall helper instead of direct OpenAI client
- remove OpenAI client initialization from chat router

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68b09f1fa0848320ac7bab1d459b419a