### PR TITLE
feat: add dashboard header

### DIFF
--- a/front-end/app/(protected)/dashboard/page.tsx
+++ b/front-end/app/(protected)/dashboard/page.tsx
@@ -5,7 +5,6 @@
 
 import { useEffect, useRef, useState } from "react";
 import { ChevronLeft, ChevronRight, Copy, Trash2, Pencil, Star, User, RotateCcw } from "lucide-react";
-import Header from "@/components/header";
 import Sidebar from "@/components/sidebar";
 import ChatInput from "@/components/chat-input";
 import ReactMarkdown from "react-markdown";
@@ -32,8 +31,8 @@ export default function ChatDashboard() {
   const [messages, setMessages] = useState<ChatMessage[]>([]);
   const [typing, setTyping] = useState(false);
   const [userId, setUserId] = useState<string | null>(null);
-  const [user, setUser] = useState<any | null>(null);
-  const [folders, setFolders] = useState<any[]>([]);
+  const [user, setUser] = useState<Record<string, unknown> | null>(null);
+  const [folders, setFolders] = useState<Record<string, unknown>[]>([]);
 
   const listRef = useRef<HTMLDivElement>(null);
   const [autoScroll, setAutoScroll] = useState(true);
@@ -150,7 +149,6 @@ console.log("Hello World!");
 
   return (
     <div className="min-h-screen flex flex-col">
-      <Header />
       <div className="flex flex-1 min-h-0">
         {navOpen && <Sidebar folders={folders} />}
 

--- a/front-end/app/(protected)/layout.tsx
+++ b/front-end/app/(protected)/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import "../globals.css";
 import { ThemeProvider } from "@/components/theme-provider";
+import DashboardHeader from "@/components/dashboard-header";
 import { createServerClient } from "@supabase/ssr";
 import { cookies } from "next/headers";
 import { redirect } from "next/navigation";
@@ -31,10 +32,16 @@ export default async function RootLayout({
   if (!session) {
     redirect("/marketing");
   }
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
   return (
     <html lang="en" suppressHydrationWarning>
       <body className="min-h-screen antialiased">
-        <ThemeProvider>{children}</ThemeProvider>
+        <ThemeProvider>
+          <DashboardHeader user={user} />
+          {children}
+        </ThemeProvider>
       </body>
     </html>
   );

--- a/front-end/components/dashboard-header.tsx
+++ b/front-end/components/dashboard-header.tsx
@@ -1,0 +1,78 @@
+"use client";
+
+import Link from "next/link";
+import Image from "next/image";
+import { Bell } from "lucide-react";
+import * as DropdownMenu from "@radix-ui/react-dropdown-menu";
+import { supabase } from "@/lib/supabase";
+import type { User } from "@supabase/supabase-js";
+
+export default function DashboardHeader({ user }: { user: User | null }) {
+  return (
+    <header className="sticky top-0 z-50 w-full border-b border-hairline bg-[hsl(var(--bg)/0.85)] backdrop-blur">
+      <div className="h-16 px-4 flex items-center justify-between">
+        <Link href="/" className="font-medium tracking-tight text-xl">
+          brand<span className="text-primary">OS</span>
+        </Link>
+        <div className="flex items-center gap-3">
+          <Link
+            href="/upgrade"
+            className="rounded-md px-3 py-2 bg-primary text-primaryFg text-sm hover:opacity-95 transition"
+          >
+            Upgrade
+          </Link>
+          <Bell className="h-5 w-5" />
+          <DropdownMenu.Root>
+            <DropdownMenu.Trigger asChild>
+              <button className="w-8 h-8 rounded-full overflow-hidden border">
+                {user?.avatar_url ? (
+                  <Image
+                    src={user.avatar_url}
+                    alt="Avatar"
+                    width={32}
+                    height={32}
+                    className="object-cover"
+                  />
+                ) : (
+                  <div className="w-full h-full bg-muted flex items-center justify-center text-sm">
+                    ?
+                  </div>
+                )}
+              </button>
+            </DropdownMenu.Trigger>
+            <DropdownMenu.Content
+              align="end"
+              className="min-w-[160px] bg-popover text-popover-foreground rounded-md shadow-md p-1"
+            >
+              <DropdownMenu.Item asChild>
+                <Link
+                  href="/account"
+                  className="block px-2 py-1.5 rounded-md text-sm hover:bg-muted"
+                >
+                  View account
+                </Link>
+              </DropdownMenu.Item>
+              <DropdownMenu.Item asChild>
+                <Link
+                  href="/settings"
+                  className="block px-2 py-1.5 rounded-md text-sm hover:bg-muted"
+                >
+                  Settings
+                </Link>
+              </DropdownMenu.Item>
+              <DropdownMenu.Item
+                onSelect={async () => {
+                  await supabase.auth.signOut();
+                }}
+                className="px-2 py-1.5 rounded-md text-sm hover:bg-muted cursor-pointer"
+              >
+                Sign out
+              </DropdownMenu.Item>
+            </DropdownMenu.Content>
+          </DropdownMenu.Root>
+        </div>
+      </div>
+    </header>
+  );
+}
+

--- a/front-end/components/modals/login-modal.tsx
+++ b/front-end/components/modals/login-modal.tsx
@@ -44,8 +44,9 @@ export default function LoginModal({
     // success
     onOpenChangeAction(false);   // close modal
     onSuccess?.();               // parent does router.push("/dashboard")
-  } catch (err: any) {
-    setError(err?.message ?? "Unexpected error");
+  } catch (err: unknown) {
+    const message = err instanceof Error ? err.message : "Unexpected error";
+    setError(message);
   } finally {
     setSubmitting(false);
   }


### PR DESCRIPTION
## Summary
- add dashboard header with upgrade button, notifications, and account menu
- fetch user in protected layout and use new header across authenticated pages
- replace explicit `any` types and improve login error handling to satisfy lint

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b0afdc99f4832094d49154dc4f1807