### PR TITLE
Adjust dashboard header spacing and avatar size

### DIFF
--- a/front-end/components/dashboard-header.tsx
+++ b/front-end/components/dashboard-header.tsx
@@ -10,27 +10,27 @@ import type { User } from "@supabase/supabase-js";
 export default function DashboardHeader({ user }: { user: User | null }) {
   return (
     <header className="sticky top-0 z-50 w-full border-b border-hairline bg-[hsl(var(--bg)/0.85)] backdrop-blur">
-      <div className="h-16 px-4 flex items-center justify-between">
+      <div className="h-20 px-6 sm:px-8 flex items-center justify-between">
         <Link href="/" className="font-medium tracking-tight text-xl">
           brand<span className="text-primary">OS</span>
         </Link>
-        <div className="flex items-center gap-3">
+        <div className="flex items-center gap-4 sm:gap-5">
           <Link
             href="/upgrade"
             className="rounded-md px-3 py-2 bg-primary text-primaryFg text-sm hover:opacity-95 transition"
           >
             Upgrade
           </Link>
-          <Bell className="h-5 w-5" />
+          <Bell className="h-6 w-6" />
           <DropdownMenu.Root>
             <DropdownMenu.Trigger asChild>
-              <button className="w-8 h-8 rounded-full overflow-hidden border">
+              <button className="w-10 h-10 rounded-full overflow-hidden border">
                 {user?.avatar_url ? (
                   <Image
                     src={user.avatar_url}
                     alt="Avatar"
-                    width={32}
-                    height={32}
+                    width={40}
+                    height={40}
                     className="object-cover"
                   />
                 ) : (


### PR DESCRIPTION
## Summary
- Increase dashboard header height and padding for a taller bar
- Widen space between header controls
- Scale notification icon and avatar button for taller layout

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b0b3dbdadc8320a40c295d7ee2e645