### PR TITLE
Fix avatar dropdown popover behavior

### DIFF
--- a/front-end/components/dashboard-header.tsx
+++ b/front-end/components/dashboard-header.tsx
@@ -7,11 +7,8 @@ import * as DropdownMenu from "@radix-ui/react-dropdown-menu";
 import ModeToggle from "@/components/mode-toggle";
 import { supabase } from "@/lib/supabase";
 import type { User } from "@supabase/supabase-js";
-import { useState } from "react";
 
 export default function DashboardHeader({ user }: { user: User | null }) {
-  const [open, setOpen] = useState(false);
-
   return (
     <header className="sticky top-0 z-50 w-full border-b border-hairline bg-[hsl(var(--bg)/0.85)] backdrop-blur">
       <div className="h-16 px-6 sm:px-8 flex items-center justify-between">
@@ -28,12 +25,8 @@ export default function DashboardHeader({ user }: { user: User | null }) {
 
           <ModeToggle />
           <Bell className="h-5 w-5" />
-          <DropdownMenu.Root open={open} onOpenChange={setOpen}>
-            <DropdownMenu.Trigger
-              asChild
-              onMouseEnter={() => setOpen(true)}
-              onMouseLeave={() => setOpen(false)}
-            >
+          <DropdownMenu.Root>
+            <DropdownMenu.Trigger asChild>
               <button className="w-8 h-8 rounded-full overflow-hidden border">
 
                 {user?.avatar_url ? (
@@ -54,8 +47,6 @@ export default function DashboardHeader({ user }: { user: User | null }) {
             <DropdownMenu.Content
               align="end"
               className="min-w-[160px] bg-popover text-popover-foreground rounded-md shadow-md p-1"
-              onMouseEnter={() => setOpen(true)}
-              onMouseLeave={() => setOpen(false)}
             >
               <DropdownMenu.Item asChild>
                 <Link


### PR DESCRIPTION
## Summary
- remove hover-based toggling for account avatar dropdown
- rely on Radix UI default click behavior so popover stays open until clicking outside

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68b0b65c70188320860091553242bc2d