### PR TITLE
feat: add settings page

### DIFF
--- a/front-end/app/(protected)/settings/page.tsx
+++ b/front-end/app/(protected)/settings/page.tsx
@@ -1,0 +1,45 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import ModeToggle from "@/components/mode-toggle";
+
+export default function SettingsPage() {
+  const [emailNotifications, setEmailNotifications] = useState(false);
+
+  useEffect(() => {
+    const stored = localStorage.getItem("emailNotifications");
+    if (stored !== null) {
+      setEmailNotifications(stored === "true");
+    }
+  }, []);
+
+  useEffect(() => {
+    localStorage.setItem("emailNotifications", String(emailNotifications));
+  }, [emailNotifications]);
+
+  return (
+    <main className="max-w-3xl mx-auto p-6 space-y-8">
+      <section>
+        <h2 className="text-xl font-semibold mb-2">Appearance</h2>
+        <div className="flex items-center justify-between">
+          <span>Theme</span>
+          <ModeToggle />
+        </div>
+      </section>
+
+      <section>
+        <h2 className="text-xl font-semibold mb-2">Notifications</h2>
+        <label className="flex items-center justify-between">
+          <span>Email notifications</span>
+          <input
+            type="checkbox"
+            checked={emailNotifications}
+            onChange={(e) => setEmailNotifications(e.target.checked)}
+            className="h-4 w-4"
+          />
+        </label>
+      </section>
+    </main>
+  );
+}
+


### PR DESCRIPTION
## Summary
- add protected settings page with theme and notification preferences

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b101f776e083208ac9916a62d7561c