### PR TITLE
Add root layout and adjust segment layouts

### DIFF
--- a/front-end/app/(marketing)/layout.tsx
+++ b/front-end/app/(marketing)/layout.tsx
@@ -1,26 +1,15 @@
-import { Metadata } from "next/dist/lib/metadata/types/metadata-interface";
-import "../globals.css";
-import { ThemeProvider } from "@/components/theme-provider";
+import type { Metadata } from "next";
+import type { ReactNode } from "react";
 
 export const metadata: Metadata = {
   title: "brandOS",
   description: "AI brand creation.",
-}
-  
+};
 
-
-
-
-export default function RootLayout({
+export default function MarketingLayout({
   children,
 }: {
-  children: React.ReactNode
+  children: ReactNode;
 }) {
-  return (
-    <html lang="en">
-      <body>
-        <ThemeProvider>{children}</ThemeProvider>
-      </body>
-    </html>
-  )
+  return <>{children}</>;
 }

--- a/front-end/app/(protected)/layout.tsx
+++ b/front-end/app/(protected)/layout.tsx
@@ -1,21 +1,20 @@
 import type { Metadata } from "next";
-import "../globals.css";
-import { ThemeProvider } from "@/components/theme-provider";
+import type { ReactNode } from "react";
 import DashboardHeader from "@/components/dashboard-header";
+import { getCurrentUser } from "@/lib/utils";
 import { createServerClient } from "@supabase/ssr";
 import { cookies } from "next/headers";
 import { redirect } from "next/navigation";
-import { getCurrentUser } from "@/lib/utils";
 
 export const metadata: Metadata = {
   title: "brandOS",
   description: "AI-powered brand creation and growth platform",
 };
 
-export default async function RootLayout({
+export default async function ProtectedLayout({
   children,
 }: {
-  children: React.ReactNode;
+  children: ReactNode;
 }) {
   const cookieStore = await cookies();
   const supabase = createServerClient(
@@ -27,22 +26,21 @@ export default async function RootLayout({
       },
     }
   );
+
   const {
     data: { session },
   } = await supabase.auth.getSession();
+
   if (!session) {
     redirect("/marketing");
   }
+
   const user = await getCurrentUser(supabase);
+
   return (
-    <html lang="en" suppressHydrationWarning>
-      <body className="min-h-screen antialiased">
-        <ThemeProvider>
-          <DashboardHeader user={user} />
-          {children}
-        </ThemeProvider>
-      </body>
-    </html>
+    <>
+      <DashboardHeader user={user} />
+      {children}
+    </>
   );
 }
-

--- a/front-end/app/layout.tsx
+++ b/front-end/app/layout.tsx
@@ -1,0 +1,23 @@
+import type { Metadata } from "next";
+import type { ReactNode } from "react";
+import "./globals.css";
+import { ThemeProvider } from "@/components/theme-provider";
+
+export const metadata: Metadata = {
+  title: "brandOS",
+  description: "AI-powered brand creation and growth platform",
+};
+
+export default function RootLayout({
+  children,
+}: {
+  children: ReactNode;
+}) {
+  return (
+    <html lang="en" suppressHydrationWarning>
+      <body className="min-h-screen antialiased">
+        <ThemeProvider>{children}</ThemeProvider>
+      </body>
+    </html>
+  );
+}


### PR DESCRIPTION
## Summary
- add a root `app/layout.tsx` to provide the required html/body structure and supply the shared theme provider
- refactor the protected segment layout to rely on the root layout while keeping the Supabase auth gate and dashboard header
- simplify the marketing layout to match the new root layout structure

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68c9e5e7b0dc8320a68803680539416c